### PR TITLE
Fix include-all flag location option

### DIFF
--- a/ics-toMarkdown.py
+++ b/ics-toMarkdown.py
@@ -25,7 +25,7 @@ def main():
     # If include-all flag is set, set all relevant flags
     if(opts.include_all):
         opts.include_datetime = True
-        opts.include_locations = True
+        opts.include_location = True
         opts.include_description = True
 
     # Read input ICS file to calendar object


### PR DESCRIPTION
## Summary
- ensure the `--include-all` flag enables location output by toggling the correct option name

## Testing
- python ics-toMarkdown.py /tmp/sample.ics --include-all

------
https://chatgpt.com/codex/tasks/task_e_68df246156488326a20cc3d2e8aad90d